### PR TITLE
Fix backup data file name issue.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-wacai",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-wacai",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "private": true,
   "dependencies": {
     "@babel/core": "7.2.2",

--- a/server/router/dbRouter/cleanupBackupData.js
+++ b/server/router/dbRouter/cleanupBackupData.js
@@ -28,13 +28,13 @@ router.get('/cleanupBackupData', (req, res) => {
       .filter((fileName) => dateRegex.test(fileName))
       .filter((fileName) => {
         let dateMark = dateRegex.exec(fileName)[1];
-        let currDate = new Date(dateMark);
+        let currDate = new Date(dateMark.replace(/_/g, ':'));
         return currDate > startDate && currDate < endDate;
       });
 
     needToDeleteFiles.map((fileName) => {
       let dateMark = dateRegex.exec(fileName)[1];
-      let currDate = new Date(dateMark);
+      let currDate = new Date(dateMark.replace(/_/g, ':'));
       if (currDate > startDate && currDate < endDate) {
         fs.unlinkSync('./backupData/' + fileName);
       }

--- a/server/router/dbRouter/scheduleBackup.js
+++ b/server/router/dbRouter/scheduleBackup.js
@@ -20,7 +20,7 @@ router.get('/createScheduleBackup', (req, res) => {
   try {
     const dailyJob = schedule.scheduleJob('my-daily-job', rule, function () {
       const now = new Date();
-      const newFileNameSuffix = `${now.getFullYear()}-${padZero(now.getMonth() + 1)}-${padZero(now.getDate())}T${padZero(now.getHours())}-${padZero(now.getMinutes())}-${padZero(now.getSeconds())}`;
+      const newFileNameSuffix = `${now.getFullYear()}-${padZero(now.getMonth() + 1)}-${padZero(now.getDate())}T${padZero(now.getHours())}_${padZero(now.getMinutes())}_${padZero(now.getSeconds())}`;
       fs.copyFileSync(`./${dbFileName}.db`, `./${backupDataFolder}/${dbFileName}-${newFileNameSuffix}.db`);
     });
 


### PR DESCRIPTION
When generating back up data files, windows system does not support ":" in file name.

Solution:

Replace colon `:` with underscore `_`.